### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
Potential fix for [https://github.com/ruchernchong/cloudflare-speedtest-cli/security/code-scanning/1](https://github.com/ruchernchong/cloudflare-speedtest-cli/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required. Based on the workflow's steps, the following permissions are necessary:
- `contents: read` to allow the workflow to read repository contents.
- `contents: write` to allow the `changesets/action@v1` step to create a release pull request.

This ensures that the workflow has only the permissions it needs and no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal workflow configuration to improve release process security. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->